### PR TITLE
fix: update beanstalkd dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-runtime": "^5.8.25",
-    "beanstalkd": "^2.0.1",
+    "beanstalkd": "^2.2.2",
     "bluebird": "~2.5.3",
     "debug": "^2.2.0",
     "lodash": "^3.10.1",


### PR DESCRIPTION
Use fixes from https://github.com/burstable/node-beanstalkd-client/pull/9

Currently any PUT command with non-ascii payload will fail